### PR TITLE
Skip empty strings in translation to avoid unnecessary errors

### DIFF
--- a/src/core/translator.ts
+++ b/src/core/translator.ts
@@ -15,6 +15,9 @@ export async function plaintranslate(
   to: string,
   skipModuleKeys: string[]
 ): Promise<string> {
+  // Check for empty strings and return immediately if empty
+  if (str.trim() === '') return str;
+
   // step: map the subset of string need to be ignored
   let {
     word: ignored_str,

--- a/src/core/translator.ts
+++ b/src/core/translator.ts
@@ -16,7 +16,7 @@ export async function plaintranslate(
   skipModuleKeys: string[]
 ): Promise<string> {
   // Check for empty strings and return immediately if empty
-  if (str.trim() === '') return str;
+  if (str === '') return str;
 
   // step: map the subset of string need to be ignored
   let {

--- a/src/core/translator.ts
+++ b/src/core/translator.ts
@@ -16,7 +16,7 @@ export async function plaintranslate(
   skipModuleKeys: string[]
 ): Promise<string> {
   // Check for empty strings and return immediately if empty
-  if (str === '') return str;
+  if (str.trim() === '') return str;
 
   // step: map the subset of string need to be ignored
   let {


### PR DESCRIPTION
Related to #59

Implements a check to skip empty strings in the translation process to enhance efficiency and reduce errors.

- Adds a condition at the beginning of the `plaintranslate` function in `src/core/translator.ts` to immediately return the input string if it is empty, effectively skipping the translation process for empty strings.
- Utilizes `str.trim() === ''` to check for empty strings, ensuring that strings containing only whitespace are also skipped.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mololab/json-translator/issues/59?shareId=62842aea-20d2-4b97-aec9-e0f425fc149a).