### PR TITLE
feat: add support for all translation modules in package

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,18 +53,18 @@ This package will provide you to translate your JSON/YAML files or JSON objects 
 
 ### ⏳ Package Support:
 
-|    Translation Module    | Support |   FREE    |
-| :----------------------: | :-----: | :-------: |
-|     Google Translate     |   ✅    | `✅ FREE` |
-|    Google Translate 2    |   ❌    |    ❌     |
-| Microsoft Bing Translate |   ❌    |    ❌     |
-|     Libre Translate      |   ❌    |    ❌     |
-|     Argos Translate      |   ❌    |    ❌     |
-|     DeepL Translate      |   ❌    |    ❌     |
-|          gpt-4o          |   ❌    |    ❌     |
-|      gpt-3.5-turbo       |   ❌    |    ❌     |
-|          gpt-4           |   ❌    |    ❌     |
-|       gpt-4o-mini        |   ❌    |    ❌     |
+|    Translation Module    | Support |                   FREE                    |
+| :----------------------: | :-----: | :---------------------------------------: |
+|     Google Translate     |   ✅    |                 `✅ FREE`                 |
+|    Google Translate 2    |   ✅    |                 `✅ FREE`                 |
+| Microsoft Bing Translate |   ✅    |                 `✅ FREE`                 |
+|     Libre Translate      |   ✅    |                 `✅ FREE`                 |
+|     Argos Translate      |   ✅    |                 `✅ FREE`                 |
+|     DeepL Translate      |   ✅    | `require API KEY (DEEPL_API_KEY as env)`  |
+|          gpt-4o          |   ✅    | `require API KEY (OPENAI_API_KEY as env)` |
+|      gpt-3.5-turbo       |   ✅    | `require API KEY (OPENAI_API_KEY as env)` |
+|          gpt-4           |   ✅    | `require API KEY (OPENAI_API_KEY as env)` |
+|       gpt-4o-mini        |   ✅    | `require API KEY (OPENAI_API_KEY as env)` |
 
 `Browser support will come soon...`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,32 +5,28 @@ import { objectTranslator } from './core/json_object';
 import { TranslationConfig, TranslationModules } from './modules/modules';
 import { default_concurrency_limit, default_fallback } from './utils/micro';
 
-// TODO: fix to get from user
-export async function translateWord(word: string, from: string, to: string) {
-  let config: TranslationConfig = {
-    moduleKey: 'google',
-    TranslationModule: TranslationModules['google'],
-    concurrencyLimit: default_concurrency_limit,
-    fallback: default_fallback,
-  };
+const defaults: TranslationConfig = {
+  moduleKey: 'google',
+  TranslationModule: TranslationModules['google'],
+  concurrencyLimit: default_concurrency_limit,
+  fallback: default_fallback,
+};
 
+export async function translateWord(
+  word: string,
+  from: string,
+  to: string,
+  config: TranslationConfig = defaults
+) {
   return await plaintranslate(config, word, from, to, []);
 }
-// TODO: fix to get from user
 export async function translateObject(
   object: translatedObject,
   from: string,
-  to: string[]
+  to: string[],
+  config: TranslationConfig = defaults
 ): Promise<translatedObject | translatedObject[]> {
   let hard_copy = JSON.parse(JSON.stringify(object));
-
-  let config: TranslationConfig = {
-    moduleKey: 'google',
-    TranslationModule: TranslationModules['google'],
-    concurrencyLimit: default_concurrency_limit,
-    fallback: default_fallback,
-  };
-
   return objectTranslator(config, hard_copy, from, to);
 }
 
@@ -38,15 +34,9 @@ export async function translateFile(
   objectPath: string,
   from: string,
   to: string[],
-  newFileName: string
+  newFileName: string,
+  config: TranslationConfig = defaults
 ) {
-  let config: TranslationConfig = {
-    moduleKey: 'google',
-    TranslationModule: TranslationModules['google'],
-    concurrencyLimit: default_concurrency_limit,
-    fallback: default_fallback,
-  };
-
   return fileTranslator(config, objectPath, from, to, newFileName);
 }
 


### PR DESCRIPTION
This is a simple change to enable support for all functions in the package. 

The config that was being defined by each function was extracted into a `defaults` const & the `TranslateConfig` object became an optional argument that defaults to our new shared config. 

If no config is passed, we use the same config object we were using before so there is no breaking change.

If a config is passed, the package functions can use the other translation options outside of the `google` default. 