### PR TITLE
fix: export translation module config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,11 @@ import { initializeCli } from './cli/cli';
 import { plaintranslate } from './core/translator';
 import { fileTranslator } from './core/json_file';
 import { objectTranslator } from './core/json_object';
-import { TranslationConfig, TranslationModules } from './modules/modules';
+import {
+  TranslationConfig,
+  TranslationModules,
+  TranslationModule,
+} from './modules/modules';
 import { default_concurrency_limit, default_fallback } from './utils/micro';
 
 const defaults: TranslationConfig = {
@@ -48,3 +52,7 @@ export async function runCli() {
 export interface translatedObject {
   [key: string]: any;
 }
+
+export { TranslationModules };
+
+export type { TranslationConfig, TranslationModule };


### PR DESCRIPTION
Add imports for the `TranslationModule` type & export `TranslationModule`, `TranslationConfig`, & the `TranslationModules` object to allow a user to pass a defined translation object to our functions to override the config. 