### PR TITLE
Add translation functions via new GROQ models

### DIFF
--- a/src/modules/functions.ts
+++ b/src/modules/functions.ts
@@ -210,7 +210,66 @@ export async function translateWithGPT(
   model: string,
   str: string,
   from: string,
+  to: string,
+) {
+  return translateWithLLM(model, str, from, to, 'openai');
+}
+
+export async function translateWithGemma7B(
+  str: string,
+  from: string,
   to: string
+) {
+  return translateWithGPT('gemma-7b-it', str, from, to);
+}
+
+export async function translateWithGemma9B(
+  str: string,
+  from: string,
+  to: string
+) {
+  return translateWithGPT('gemma2-9b-it', str, from, to);
+}
+
+export async function translateWithMixtral8x7B(
+  str: string,
+  from: string,
+  to: string
+) {
+  return translateWithGPT('mixtral-8x7b-32768', str, from, to);
+}
+
+export async function translateWithLlama8B(
+  str: string,
+  from: string,
+  to: string
+) {
+  return translateWithGPT('llama3-8b-8192', str, from, to);
+}
+
+export async function translateWithLlama70B(
+  str: string,
+  from: string,
+  to: string
+) {
+  return translateWithGPT('llama3-70b-8192', str, from, to);
+}
+
+export async function translateWithGroq(
+  model: string,
+  str: string,
+  from: string,
+  to: string
+) {
+  return translateWithLLM(model, str, from, to, 'groq');
+}
+
+export async function translateWithLLM(
+  model: string,
+  str: string,
+  from: string,
+  to: string,
+  provider: 'openai' | 'groq'
 ) {
   type ChatCompletionRequestMessage = {
     role: 'system' | 'user' | 'assistant';
@@ -220,14 +279,30 @@ export async function translateWithGPT(
   let fromKey = getLanguageKeyFromValue(from, GTPTranslateLanguages);
   let toKey = getLanguageKeyFromValue(to, GTPTranslateLanguages);
 
-  const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
-  if (!OPENAI_API_KEY) {
-    warn('process.env.OPENAI_API_KEY is not defined');
-  }
+  let openai: OpenAI;
 
-  const openai = new OpenAI({
-    apiKey: OPENAI_API_KEY,
-  });
+  if (provider === 'openai') {
+    const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+    if (!OPENAI_API_KEY) {
+      warn('process.env.OPENAI_API_KEY is not defined');
+    }
+
+    openai = new OpenAI({
+      apiKey: OPENAI_API_KEY,
+    });
+  } else if (provider === 'groq') {
+    const GROQ_API_KEY = process.env.GROQ_API_KEY;
+    if (!GROQ_API_KEY) {
+      warn('process.env.GROQ_API_KEY is not defined');
+    }
+
+    openai = new OpenAI({
+      baseURL: 'https://api.groq.com/openai/v1',
+      apiKey: GROQ_API_KEY,
+    });
+  } else {
+    throw new Error(`Unsupported provider: ${provider}`);
+  }
 
   try {
     let conversationHistory: ChatCompletionRequestMessage[] = [

--- a/src/modules/modules.ts
+++ b/src/modules/modules.ts
@@ -9,6 +9,11 @@ import {
   translateWithGPT4o,
   translateWithGPT4,
   translateWithGPT4oMini,
+  translateWithGemma7B,
+  translateWithGemma9B,
+  translateWithMixtral8x7B,
+  translateWithLlama8B,
+  translateWithLlama70B
 } from './functions';
 import {
   GoogleTranslateLanguages,
@@ -108,5 +113,40 @@ export const TranslationModules: TranslationModulesType = {
     requirements: ['"OPENAI_API_KEY" as env'],
     languages: GTPTranslateLanguages,
     translate: translateWithGPT4oMini,
+  },
+  'gemma-7b': {
+    name: 'gemma-7b model',
+    altName: '\x1b[33m**NEW**\x1b[0m AI model: gemma-7b model',
+    requirements: ['"GROQ_API_KEY" as env'],
+    languages: GTPTranslateLanguages,
+    translate: translateWithGemma7B,
+  },
+  'gemma2-9b': {
+    name: 'gemma2-9b model',
+    altName: '\x1b[33m**NEW**\x1b[0m AI model: gemma2-9b model',
+    requirements: ['"GROQ_API_KEY" as env'],
+    languages: GTPTranslateLanguages,
+    translate: translateWithGemma9B,
+  },
+  'mixtral-8x7b': {
+    name: 'mixtral-8x7b model',
+    altName: '\x1b[33m**NEW**\x1b[0m AI model: mixtral-8x7b model',
+    requirements: ['"GROQ_API_KEY" as env'],
+    languages: GTPTranslateLanguages,
+    translate: translateWithMixtral8x7B,
+  },
+  'llama3-8b': {
+    name: 'llama3-8b model',
+    altName: '\x1b[33m**NEW**\x1b[0m AI model: llama3-8b model',
+    requirements: ['"GROQ_API_KEY" as env'],
+    languages: GTPTranslateLanguages,
+    translate: translateWithLlama8B,
+  },
+  'llama3-70b': {
+    name: 'llama3-70b model',
+    altName: '\x1b[33m**NEW**\x1b[0m AI model: llama3-70b model',
+    requirements: ['"GROQ_API_KEY" as env'],
+    languages: GTPTranslateLanguages,
+    translate: translateWithLlama70B,
   },
 };


### PR DESCRIPTION
Closes #73

- Refactored `functions.ts` to use `translateWithGPT` and `translateWithGROQ` as a wrapper for `translateWithLLM`. 

- Added new AI models: `gemma-7b-it`, `gemma2-9b-it`, `mixtral-8x7b-32768`, `llama3-8b-8192`, and `llama3-70b-8192`. 

- Requires `GROQ_API_KEY`.