### PR TITLE
Fix: Prevent Array Duplication in Repeated Translations

### DIFF
--- a/src/core/json_object.ts
+++ b/src/core/json_object.ts
@@ -26,7 +26,6 @@ export async function objectTranslator(
         // Remove the keys which are already translated
         const copyObject = removeKeys(JSON.parse(JSON.stringify(object)), oldTranslations[to[indexAsNum]]);
 
-        console.log(JSON.stringify(copyObject, null, 2))
         const newTranslations = await deepDiver(
           TranslationConfig,
           copyObject,
@@ -34,13 +33,8 @@ export async function objectTranslator(
           to[indexAsNum]
         );
 
-        console.log(JSON.stringify(newTranslations, null, 2))
-
-
         // Insert old translations that we removed into the generalObject
         generalObject[indexAsNum] = mergeKeys(oldTranslations[to[indexAsNum]], newTranslations)
-
-        console.log(JSON.stringify(generalObject[indexAsNum], null, 2))
 
       })
     );

--- a/src/core/json_object.ts
+++ b/src/core/json_object.ts
@@ -26,6 +26,7 @@ export async function objectTranslator(
         // Remove the keys which are already translated
         const copyObject = removeKeys(JSON.parse(JSON.stringify(object)), oldTranslations[to[indexAsNum]]);
 
+        console.log(JSON.stringify(copyObject, null, 2))
         const newTranslations = await deepDiver(
           TranslationConfig,
           copyObject,
@@ -33,8 +34,14 @@ export async function objectTranslator(
           to[indexAsNum]
         );
 
+        console.log(JSON.stringify(newTranslations, null, 2))
+
+
         // Insert old translations that we removed into the generalObject
-        generalObject[indexAsNum] = mergeKeys(newTranslations, oldTranslations[to[indexAsNum]])
+        generalObject[indexAsNum] = mergeKeys(oldTranslations[to[indexAsNum]], newTranslations)
+
+        console.log(JSON.stringify(generalObject[indexAsNum], null, 2))
+
       })
     );
 

--- a/src/utils/console.ts
+++ b/src/utils/console.ts
@@ -104,12 +104,10 @@ export const messages = {
 
 export function removeKeys(fromDict: any, toDict: any): any {
   if (Array.isArray(fromDict) && Array.isArray(toDict)) {
-    return fromDict.map((item, index) => {
-      if (index < toDict.length && typeof item === 'object' && item !== null) {
-        return removeKeys(item, toDict[index]);
-      }
-      return item;
-    });
+    if (fromDict.length === toDict.length) {
+      return null;
+    }
+    return fromDict;
   }
 
   if (typeof fromDict !== 'object' || fromDict === null) {
@@ -133,33 +131,35 @@ export function removeKeys(fromDict: any, toDict: any): any {
 export function mergeKeys(base: any, insert: any): any {
   // If base is not an object or is null, return insert
   if (typeof base !== 'object' || base === null) {
-    return insert;
+      return insert;
   }
 
   // If insert is not an object or is null, return base
   if (typeof insert !== 'object' || insert === null) {
-    return base;
+      return base;
   }
 
   // Handle arrays
   if (Array.isArray(base) && Array.isArray(insert)) {
-    return [...base, ...insert.filter(item => !base.includes(item))];
+      console.log("base", base)
+      console.log("insert", insert)
+      return insert;
   }
 
   // Handle objects
   const result = { ...base };
 
   for (const key in insert) {
-    if (Object.prototype.hasOwnProperty.call(insert, key)) {
-      if (key in result && typeof result[key] === 'object' && typeof insert[key] === 'object') {
-        // Recursively merge nested objects or arrays
-        result[key] = mergeKeys(result[key], insert[key]);
-      } else if (!(key in result)) {
-        // Add new key-value pair from insert if it doesn't exist in base
-        result[key] = insert[key];
+      if (Object.prototype.hasOwnProperty.call(insert, key)) {
+          if (key in result && typeof result[key] === 'object' && typeof insert[key] === 'object') {
+              // Recursively merge nested objects or arrays
+              result[key] = mergeKeys(result[key], insert[key]);
+          } else if (!(key in result)) {
+              // Add new key-value pair from insert if it doesn't exist in base
+              result[key] = insert[key];
+          }
+          // If the key exists in both and is not an object, keep the base value
       }
-      // If the key exists in both and is not an object, keep the base value
-    }
   }
 
   return result;

--- a/src/utils/console.ts
+++ b/src/utils/console.ts
@@ -131,35 +131,35 @@ export function removeKeys(fromDict: any, toDict: any): any {
 export function mergeKeys(base: any, insert: any): any {
   // If base is not an object or is null, return insert
   if (typeof base !== 'object' || base === null) {
-      return insert;
+    return insert;
   }
 
   // If insert is not an object or is null, return base
   if (typeof insert !== 'object' || insert === null) {
-      return base;
+    return base;
   }
 
   // Handle arrays
   if (Array.isArray(base) && Array.isArray(insert)) {
-      console.log("base", base)
-      console.log("insert", insert)
-      return insert;
+    return insert;
   }
 
   // Handle objects
   const result = { ...base };
 
   for (const key in insert) {
-      if (Object.prototype.hasOwnProperty.call(insert, key)) {
-          if (key in result && typeof result[key] === 'object' && typeof insert[key] === 'object') {
-              // Recursively merge nested objects or arrays
-              result[key] = mergeKeys(result[key], insert[key]);
-          } else if (!(key in result)) {
-              // Add new key-value pair from insert if it doesn't exist in base
-              result[key] = insert[key];
-          }
-          // If the key exists in both and is not an object, keep the base value
+    if (Object.prototype.hasOwnProperty.call(insert, key)) {
+      if (key in result && typeof result[key] === 'object' && typeof insert[key] === 'object') {
+        // Recursively merge nested objects or arrays
+        result[key] = mergeKeys(result[key], insert[key]);
+      } else if (!(key in result)) {
+        // Add new key-value pair from insert if it doesn't exist in base
+        result[key] = insert[key];
+      } else if (key in result && typeof result[key] === 'string' && typeof insert[key] === 'string') {
+        // If key value is string take insert value
+        result[key] = insert[key];
       }
+    }
   }
 
   return result;


### PR DESCRIPTION
## Description
This PR fixes a bug where arrays in JSON files were being duplicated during repeated translations.

## Changes Made
- Added logic to preserve array structure during translations
- Prevented duplicate array elements from being created in subsequent translations
- Maintained original array size while still allowing translation updates

Related to issue https://github.com/mololab/json-translator/issues/79