### PR TITLE
fix: Support both DeepL Free and Pro API URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This package will provide you to translate your JSON/YAML files or JSON objects 
 | Microsoft Bing Translate |   ✅    |                 `✅ FREE`                 |
 |     Libre Translate      |   ✅    |                 `✅ FREE`                 |
 |     Argos Translate      |   ✅    |                 `✅ FREE`                 |
-|     DeepL Translate      |   ✅    | `require API KEY (DEEPL_API_KEY as env)`  |
+|     DeepL Translate      |   ✅    | `require API KEY (DEEPL_API_KEY as env)` </br> `optional API URL (DEEPL_API_URL as env)`  |
 |          gpt-4o          |   ✅    | `require API KEY (OPENAI_API_KEY as env)` |
 |      gpt-3.5-turbo       |   ✅    | `require API KEY (OPENAI_API_KEY as env)` |
 |          gpt-4           |   ✅    | `require API KEY (OPENAI_API_KEY as env)` |
@@ -60,7 +60,7 @@ This package will provide you to translate your JSON/YAML files or JSON objects 
 | Microsoft Bing Translate |   ✅    |                 `✅ FREE`                 |
 |     Libre Translate      |   ✅    |                 `✅ FREE`                 |
 |     Argos Translate      |   ✅    |                 `✅ FREE`                 |
-|     DeepL Translate      |   ✅    | `require API KEY (DEEPL_API_KEY as env)`  |
+|     DeepL Translate      |   ✅    | `require API KEY (DEEPL_API_KEY as env)` </br> `optional API URL (DEEPL_API_URL as env)`  |
 |          gpt-4o          |   ✅    | `require API KEY (OPENAI_API_KEY as env)` |
 |      gpt-3.5-turbo       |   ✅    | `require API KEY (OPENAI_API_KEY as env)` |
 |          gpt-4           |   ✅    | `require API KEY (OPENAI_API_KEY as env)` |

--- a/src/modules/functions.ts
+++ b/src/modules/functions.ts
@@ -144,8 +144,12 @@ export async function translateWithDeepL(
   to: string
 ): Promise<string> {
   const DEEPL_API_KEY = process.env.DEEPL_API_KEY;
+  const DEEPL_API_URL = process.env.DEEPL_API_URL || "api-free.deepl.com";
   if (!DEEPL_API_KEY) {
     warn('process.env.DEEPL_API_KEY is not defined');
+  }
+  if (!process.env.DEEPL_API_URL) {
+    warn('process.env.DEEPL_API_URL is not defined, using api-free.deepl.com as default');
   }
 
   const body = {
@@ -154,8 +158,9 @@ export async function translateWithDeepL(
     source_lang: from,
   };
 
+  console.log(DEEPL_API_URL)
   const { data } = await axios.post(
-    'https://api-free.deepl.com/v2/translate',
+    `https://${DEEPL_API_URL}/v2/translate`,
     body,
     {
       headers: {

--- a/src/modules/functions.ts
+++ b/src/modules/functions.ts
@@ -158,7 +158,6 @@ export async function translateWithDeepL(
     source_lang: from,
   };
 
-  console.log(DEEPL_API_URL)
   const { data } = await axios.post(
     `https://${DEEPL_API_URL}/v2/translate`,
     body,

--- a/src/modules/modules.ts
+++ b/src/modules/modules.ts
@@ -80,7 +80,7 @@ export const TranslationModules: TranslationModulesType = {
   deepl: {
     name: 'DeepL Translate',
     altName: 'DeepL Translate (29 languages)',
-    requirements: ['"DEEPL_API_KEY" as env'],
+    requirements: ['"DEEPL_API_KEY" and "DEEPL_API_URL" as env'],
     languages: DeepLTranslateLanguages,
     translate: translateWithDeepL,
   },


### PR DESCRIPTION
## Description
This PR adds support for DeepL Pro API by making the API URL configurable through an environment variable. Previously, the URL was hardcoded to the Free API endpoint, causing failures with Pro API keys.

### Changes
- Added `DEEPL_API_URL` environment variable support
- Default fallback to `api-free.deepl.com`
- Updated documentation with new configuration options
### Documentation
Updated README with new environment variable configuration options.

Fixes #78