### PR TITLE
Feat: Add support for JSONL file translation

### DIFF
--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs/promises';
 import * as YAML from 'yaml';
 import { matchYamlExt } from '../utils/yaml';
 import { error, messages } from '../utils/console';
+import { getFileExt } from './json_file';
 
 export async function getFile(objectPath: string) {
   let json_file: any = undefined;
@@ -37,9 +38,15 @@ export function getRootFolder(path: string) {
 }
 
 export async function saveFilePublic(path: string, data: any) {
-  // When path extension is for YAML file, then stringify with YAML encoder.
-  // Otherwise, default JSON encoder is used.
-  var json = matchYamlExt(path) ? YAML.stringify(data) : JSON.stringify(data);
+  let json = ""
+  if (getFileExt(path) === "jsonl") {
+    // If the file extension is `.jsonl`, the data is serialized as JSON Lines (JSONL) format.
+    json = data.map((item: any) => JSON.stringify(item)).join('\n');
+  } else {
+    // When path extension is for YAML file, then stringify with YAML encoder.
+    // Otherwise, default JSON encoder is used.
+    json = matchYamlExt(path) ? YAML.stringify(data) : JSON.stringify(data);
+  }
 
   await fs
     .writeFile(path, json, 'utf8')

--- a/src/core/json_file.ts
+++ b/src/core/json_file.ts
@@ -20,7 +20,12 @@ export async function fileTranslator(
     return;
   }
 
-  jsonObj = { data: JSON.parse(jsonObj) };
+  // if file extension is .jsonl convert the readed file to json with array of each line of the json file
+  if (getFileExt(objectPath) === "jsonl") {
+    jsonObj = { data: jsonObj.split('\n').map((line: string) => JSON.parse(line)) };
+  } else {
+    jsonObj = { data: JSON.parse(jsonObj) };
+  }
 
   // step: check if translation file already exists, if exists save content of it in oldTranslations
   let oldTranslations = JSON.parse("{}")
@@ -36,7 +41,7 @@ export async function fileTranslator(
 
     let response = await getFileFromPath(fileName);
     let oldTranslation = response?.jsonObj
-    try{
+    try {
       if (oldTranslation === undefined) {
         // Old Translation not found
         oldTranslations[lang] = { data: {} };
@@ -44,15 +49,18 @@ export async function fileTranslator(
         oldTranslation = { data: JSON.parse(oldTranslation) };
         oldTranslations[lang] = oldTranslation;
       }
-    } catch{
+    } catch {
       // If error in parsing json skip it
       oldTranslations[lang] = { data: {} };
     }
-    
+
   }
 
+  // if jsonl file force to translate all keys
+  const reTraslateOldTranslations = getFileExt(objectPath) === "jsonl";
+
   // step: translate object
-  let newJsonObj = await objectTranslator(TranslationConfig, jsonObj, from, to, oldTranslations);
+  let newJsonObj = await objectTranslator(TranslationConfig, jsonObj, from, to, oldTranslations, reTraslateOldTranslations);
   if (newJsonObj === undefined) {
     error(messages.file.cannot_translate);
     return;
@@ -91,13 +99,18 @@ export async function getFileFromPath(
   return { jsonObj, objectPath };
 }
 
-function getFileExt(latestPath: string): string {
+export function getFileExt(latestPath: string): string {
   // Check if source file has YAML extension and return the extension ("yml" or "yaml").
   const sourceFileMatchYamlExt = matchYamlExt(latestPath);
 
-  // When source file has "yml" or "yaml" extension, use the same in output file path.
-  // Otherwise, default "json" extension used.
-  const fileExt = sourceFileMatchYamlExt || 'json';
-
+  let fileExt = "";
+  if (latestPath.toLowerCase().endsWith('.jsonl')) {
+    // If the latestPath file extension is jsonl, keep fileExt jsonl
+    fileExt = "jsonl";
+  } else {
+    // When source file has "yml" or "yaml" extension, use the same in output file path.
+    // Otherwise, default "json" extension used.
+    fileExt = sourceFileMatchYamlExt || 'json';
+  }
   return fileExt;
 }

--- a/src/utils/console.ts
+++ b/src/utils/console.ts
@@ -110,6 +110,10 @@ export function removeKeys(fromDict: any, toDict: any): any {
     return fromDict;
   }
 
+  if (Array.isArray(fromDict)) {
+    return fromDict;
+  }
+
   if (typeof fromDict !== 'object' || fromDict === null) {
     return fromDict;
   }
@@ -141,6 +145,11 @@ export function mergeKeys(base: any, insert: any): any {
 
   // Handle arrays
   if (Array.isArray(base) && Array.isArray(insert)) {
+    return insert;
+  }
+
+  // Handle only insert is array
+  if (Array.isArray(insert)) {
     return insert;
   }
 


### PR DESCRIPTION
## Overview
This PR adds support for translating JSONL (JSON Lines) files as discussed in this issue https://github.com/mololab/json-translator/issues/50

## Implementation Details
- Added detection for JSONL file format based on file extension
- Implemented conversion of JSONL to JSON array:
  - Each line from the input JSONL file is parsed as a separate JSON object
  - All objects are collected into a single array for processing
  
- Added reverse conversion for output:
  - The translated JSON array is split into individual objects
  - Each object is written as a separate line in JSONL format

### PS:
- [skip already translated keys](https://github.com/mololab/json-translator/pull/68) feature is not implemented for jsonl files yet. 

Let me know if any changes or additional information is needed!