### PR TITLE
feat: Local llama.cpp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 <p align="center">
   <a href="https://npmcharts.com/compare/@parvineyvazov/json-translator?minimal=true">
     <img src="https://img.shields.io/npm/dt/@parvineyvazov/json-translator?label=npm%20downloads" alt="npm downloads">
-  </a> 
+  </a>
   <br>
   <a href="https://img.shields.io/npm/v/@parvineyvazov/json-translator?color=navy&label=version">
     <img src="https://img.shields.io/npm/v/@parvineyvazov/json-translator?color=navy&label=version" alt="version">
@@ -58,6 +58,7 @@ This package will provide you to translate your JSON/YAML files or JSON objects 
 |      mixtral-8x7b        |   ✅    |                         `require API KEY (GROQ_API_KEY as env)`                          |
 |       llama3-8b          |   ✅    |                         `require API KEY (GROQ_API_KEY as env)`                          |
 |       llama3-70b         |   ✅    |                         `require API KEY (GROQ_API_KEY as env)`                          |
+|       llama-cpp          |   ✅    |                                        `✅ FREE`                                         |
 
 ### ⏳ Package Support:
 
@@ -81,6 +82,7 @@ This package will provide you to translate your JSON/YAML files or JSON objects 
 |      mixtral-8x7b        |   ✅    |                         `require API KEY (GROQ_API_KEY as env)`                          |
 |       llama3-8b          |   ✅    |                         `require API KEY (GROQ_API_KEY as env)`                          |
 |       llama3-70b         |   ✅    |                         `require API KEY (GROQ_API_KEY as env)`                          |
+|       llama-cpp          |   ✅    |                                        `✅ FREE`                                         |
 
 `Browser support will come soon...`
 
@@ -377,7 +379,7 @@ const [french, georgian, japanese] = (await translator.translateObject(
   ]
 )) as Array<translator.translatedObject>; // FOR JAVASCRIPT YOU DO NOT NEED TO SPECIFY THE TYPE
 /*
-french: 
+french:
 {
   "login": {
     "title": "Connexion",
@@ -395,7 +397,7 @@ french:
   }
 }
 
-georgian: 
+georgian:
 {
   "login": {
     "title": "Შესვლა",
@@ -677,7 +679,7 @@ Make sure your terminal has admin access while running these commands to prevent
 
 * [ ] Together AI Translate module
 
-* [ ] llamacpp Translate module
+* [x] llamacpp Translate module
 
 * [ ] Google Gemini API Translate module
 

--- a/src/modules/modules.ts
+++ b/src/modules/modules.ts
@@ -17,6 +17,7 @@ import {
   translateWithMixtral8x7B,
   translateWithLlama8B,
   translateWithLlama70B,
+  translateWithLlamaCpp,
 } from './functions';
 import {
   GoogleTranslateLanguages,
@@ -173,5 +174,11 @@ export const TranslationModules: TranslationModulesType = {
     requirements: ['"GROQ_API_KEY" as env'],
     languages: GTPTranslateLanguages,
     translate: translateWithLlama70B,
+  },
+  'llama-cpp': {
+    name: 'local model',
+    altName: '[FREE] AI model: local llama.cpp model',
+    languages: GTPTranslateLanguages,
+    translate: translateWithLlamaCpp,
   },
 };

--- a/src/modules/modules.ts
+++ b/src/modules/modules.ts
@@ -176,8 +176,8 @@ export const TranslationModules: TranslationModulesType = {
     translate: translateWithLlama70B,
   },
   'llama-cpp': {
-    name: 'local model',
-    altName: '[FREE] AI model: local llama.cpp model',
+    name: 'llama.cpp model',
+    altName: '[FREE] AI model: llama.cpp model',
     languages: GTPTranslateLanguages,
     translate: translateWithLlamaCpp,
   },


### PR DESCRIPTION
## Overview

This PR adds support for using local [llama.cpp](https://github.com/ggml-org/llama.cpp/tree/master/tools/server) server instance for translations.